### PR TITLE
Setup for PHP-FPM (with Nginx or Apache)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM legalthings/apache-php:7.2
+FROM legalthings/fpm-php:7.2
 
 ADD . /app
 WORKDIR /app
 
 RUN apt-get update -y -q
 RUN apt-get install -y git
-
-ENV APACHE_DOCUMENT_ROOT /var/www/html/www
-RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 
 RUN composer install --no-dev

--- a/app.php
+++ b/app.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
-chdir(dirname(__DIR__));
-
 require_once 'vendor/autoload.php';
 
 App::run();
+

--- a/tests/_data/scenarios/basic-user.single-transition.json
+++ b/tests/_data/scenarios/basic-user.single-transition.json
@@ -18,7 +18,7 @@
         }
     },
     "states": {
-        ":initial": {
+        "initial": {
             "action": "step1",
             "transition": ":success"
         }

--- a/tests/api/Scenario/201-AddScenarioSingleTransitionCept.php
+++ b/tests/api/Scenario/201-AddScenarioSingleTransitionCept.php
@@ -23,7 +23,7 @@ $scenario = [
         ]
     ],
     'states' => [
-        ':initial' => [
+        'initial' => [
             'action' => 'step1',
             'transition' => ':success'
         ],

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -1,4 +1,0 @@
-RewriteEngine On
-
-RewriteCond %{REQUEST_FILENAME} !-s
-RewriteRule ^ /index.php [QSA,L]

--- a/www/robots.txt
+++ b/www/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /


### PR DESCRIPTION
No need for a `www` folder when serving the app with PHP-FPM. So I replaced `www/index.php` with `app.php` in root folder. We also don't need any rewriting with mod_rewrite.

Everything is forwarded to PHP-FPM. Note that we're using the default document root if anything goes wrong with forwarding.

### Nginx
```
server {
    listen         80 default_server;
    listen         [::]:80 default_server;

  location / {
    fastcgi_pass    unix:/run/php/php7.3-fpm.sock;
    include         fastcgi_params;
    fastcgi_param   SCRIPT_FILENAME  /var/www/workflow-engine/app.php;
  }
}
```

### Apache
```
<VirtualHost *:80>
	DocumentRoot /var/www/html
	ProxyPassMatch ^.*$ unix:/var/run/php/php7.3-fpm.sock|fcgi://localhost/var/www/workflow-engine/app.php
</VirtualHost>
```